### PR TITLE
fix: void-element siblings dropped (#17) + empty-string class var leak (#18); bump v0.2.3

### DIFF
--- a/pkg/gopug/issue17_test.go
+++ b/pkg/gopug/issue17_test.go
@@ -1,0 +1,49 @@
+package gopug
+
+import "testing"
+
+// Issue #17: a bare buffered-output line (`= expr`) is silently dropped when it
+// immediately follows a void element (br/img/hr/…) at the same indentation.
+// Root cause: parseTag adopted same-depth *following-line* content as a child of
+// the tag; void elements never render their children, so the node vanished.
+
+func TestIssue17BufferedCodeAfterBr(t *testing.T) {
+	src := "div\n  | Hello\n  br\n  = \"world\"\n"
+	out := renderTest(t, src, nil)
+	assertEqual(t, out, "<div>Hello<br>world</div>")
+}
+
+func TestIssue17UnescapedCodeAfterBr(t *testing.T) {
+	src := "div\n  br\n  != \"<b>hi</b>\"\n"
+	out := renderTest(t, src, nil)
+	assertEqual(t, out, "<div><br><b>hi</b></div>")
+}
+
+func TestIssue17TextAfterBr(t *testing.T) {
+	src := "div\n  br\n  | after\n"
+	out := renderTest(t, src, nil)
+	assertEqual(t, out, "<div><br>after</div>")
+}
+
+func TestIssue17BufferedCodeAfterVoidElements(t *testing.T) {
+	for _, void := range []string{"img", "hr", "input"} {
+		src := "div\n  " + void + "\n  = \"world\"\n"
+		out := renderTest(t, src, nil)
+		assertContains(t, out, "world")
+	}
+}
+
+// A bare `= expr` following a normal (non-void) tag must be a *sibling*, not a
+// child of that tag.
+func TestIssue17BufferedCodeIsSiblingNotChild(t *testing.T) {
+	src := "p\n= \"world\"\np\n"
+	out := renderTest(t, src, nil)
+	assertEqual(t, out, "<p></p>world<p></p>")
+}
+
+// Inline buffered output on the same line as the tag must still be a child.
+func TestIssue17InlineBufferedCodeStillChild(t *testing.T) {
+	src := "p= \"world\"\n"
+	out := renderTest(t, src, nil)
+	assertEqual(t, out, "<p>world</p>")
+}

--- a/pkg/gopug/issue18_test.go
+++ b/pkg/gopug/issue18_test.go
@@ -1,0 +1,38 @@
+package gopug
+
+import "testing"
+
+// Issue #18: class= bound to a variable whose value is the empty string leaked
+// the variable's *name* as a literal class token. Root cause: the class
+// resolution fallback kept an unresolved word literally, unable to tell a
+// static class token from a variable that resolved to "".
+
+func TestIssue18EmptyStringVarDoesNotLeakName(t *testing.T) {
+	src := "- var cls = \"\"\ndiv(class=cls) hi\n"
+	out := renderTest(t, src, nil)
+	assertEqual(t, out, `<div class="">hi</div>`)
+}
+
+func TestIssue18ConditionalVisibilityPattern(t *testing.T) {
+	src := "- var c = show ? \"\" : \"d-none\"\ndiv(class=c) x\n"
+
+	shown := renderTest(t, src, map[string]interface{}{"show": true})
+	assertEqual(t, shown, `<div class="">x</div>`)
+
+	hidden := renderTest(t, src, map[string]interface{}{"show": false})
+	assertEqual(t, hidden, `<div class="d-none">x</div>`)
+}
+
+// Non-empty variable values must still resolve normally.
+func TestIssue18NonEmptyVarStillWorks(t *testing.T) {
+	src := "- var cls = \"active\"\ndiv(class=cls) hi\n"
+	out := renderTest(t, src, nil)
+	assertEqual(t, out, `<div class="active">hi</div>`)
+}
+
+// A static quoted class list must keep its literal tokens.
+func TestIssue18StaticClassListPreserved(t *testing.T) {
+	src := `div(class="foo bar") hi`
+	out := renderTest(t, src, nil)
+	assertEqual(t, out, `<div class="foo bar">hi</div>`)
+}

--- a/pkg/gopug/parser.go
+++ b/pkg/gopug/parser.go
@@ -200,7 +200,7 @@ func (p *Parser) parseTag() (Node, error) {
 		}
 	}
 
-	if (p.cur.Type == TokenText || p.cur.Type == TokenInterpolation || p.cur.Type == TokenInterpolationUnescape) && p.cur.IndentDepth == currentDepth {
+	if (p.cur.Type == TokenText || p.cur.Type == TokenInterpolation || p.cur.Type == TokenInterpolationUnescape) && p.cur.IndentDepth == currentDepth && p.cur.Line == tag.Line {
 		line := p.cur.Line
 		col := p.cur.Col
 		nodes := p.collectTextRun(currentDepth)
@@ -217,7 +217,7 @@ func (p *Parser) parseTag() (Node, error) {
 		}
 	}
 
-	if p.cur.Type == TokenCodeBuffered && p.cur.IndentDepth == currentDepth {
+	if p.cur.Type == TokenCodeBuffered && p.cur.IndentDepth == currentDepth && p.cur.Line == tag.Line {
 		code := &CodeNode{Expression: p.cur.Value, Type: CodeBuffered, Line: p.cur.Line, Col: p.cur.Col}
 		p.advance()
 		p.skipNewlines()
@@ -225,7 +225,7 @@ func (p *Parser) parseTag() (Node, error) {
 		return tag, nil
 	}
 
-	if p.cur.Type == TokenCodeUnescaped && p.cur.IndentDepth == currentDepth {
+	if p.cur.Type == TokenCodeUnescaped && p.cur.IndentDepth == currentDepth && p.cur.Line == tag.Line {
 		code := &CodeNode{Expression: p.cur.Value, Type: CodeUnescaped, Line: p.cur.Line, Col: p.cur.Col}
 		p.advance()
 		p.skipNewlines()

--- a/pkg/gopug/runtime.go
+++ b/pkg/gopug/runtime.go
@@ -684,10 +684,12 @@ func (r *Runtime) renderTag(tag *TagNode) error {
 								evaluated = strings.Join(activeClasses, " ")
 							default:
 								inner := rawValExpr
+								wasQuoted := false
 								if len(inner) >= 2 &&
 									((inner[0] == '"' && inner[len(inner)-1] == '"') ||
 										(inner[0] == '\'' && inner[len(inner)-1] == '\'')) {
 									inner = inner[1 : len(inner)-1]
+									wasQuoted = true
 								}
 								words := strings.Fields(inner)
 								var resolved []string
@@ -705,7 +707,12 @@ func (r *Runtime) renderTag(tag *TagNode) error {
 									v, _ := r.evaluateExpr(word)
 									if v != "" {
 										resolved = append(resolved, v)
-									} else if word != "" {
+									} else if wasQuoted && word != "" {
+										// Static class token from a quoted list —
+										// keep it literally. An unquoted word that
+										// resolved to "" is a variable/expression
+										// whose value is empty, so drop it rather
+										// than leaking the identifier name.
 										resolved = append(resolved, word)
 									}
 								}
@@ -717,10 +724,12 @@ func (r *Runtime) renderTag(tag *TagNode) error {
 							}
 						} else {
 							inner := rawValExpr
+							wasQuoted := false
 							if len(inner) >= 2 &&
 								((inner[0] == '"' && inner[len(inner)-1] == '"') ||
 									(inner[0] == '\'' && inner[len(inner)-1] == '\'')) {
 								inner = inner[1 : len(inner)-1]
+								wasQuoted = true
 							}
 							words := strings.Fields(inner)
 							var resolved []string
@@ -738,7 +747,9 @@ func (r *Runtime) renderTag(tag *TagNode) error {
 								v, _ := r.evaluateExpr(word)
 								if v != "" {
 									resolved = append(resolved, v)
-								} else if word != "" {
+								} else if wasQuoted && word != "" {
+									// See note above: only keep literal tokens that
+									// came from a quoted static class list.
 									resolved = append(resolved, word)
 								}
 							}

--- a/pkg/gopug/version.go
+++ b/pkg/gopug/version.go
@@ -11,4 +11,4 @@ package gopug
 //	-ldflags "-X github.com/sinfulspartan/go-pug/pkg/gopug.Version=vX.Y.Z"
 //
 // so the binary always reports the exact tag that was built from.
-var Version = "v0.2.2"
+var Version = "v0.2.3"


### PR DESCRIPTION
Fixes #17 and #18, and bumps the version to **v0.2.3**.

## #17 — output/text sibling dropped after a void element
A bare `= expr`, `!= expr`, or plain text line immediately following a void element (`br`/`img`/`hr`/`input`/…) at the same indentation was silently dropped — no error, no output.

**Root cause:** `parseTag` decided whether inline content belonged to a tag using indent depth alone. A following-line sibling at *equal* depth was therefore adopted as a *child* of the preceding tag. Void elements never render their children, so the node vanished. (For non-void tags the AST was also wrong — child instead of sibling — it just happened to render acceptably.)

**Fix:** the three inline-content checks now also require the content to be on the same line as the tag (`p.cur.Line == tag.Line`), so same-depth following-line content falls through to the sibling loop. Inline content (`p= "x"`) is unaffected.

## #18 — `class=<var>` leaks the variable name when the value is `""`
`div(class=cls)` with `cls == ""` emitted `class="cls"` (the variable's *name*) instead of an empty class.

**Root cause:** the class-token resolver keeps an unresolved word literally so static class lists (`class="foo bar"`) survive, but it couldn't distinguish a static token from an unquoted expression that resolved to `""`.

**Fix:** literal fallback now only applies to tokens from a **quoted** static class list; an unquoted word that resolves to `""` is dropped.

## Tests
Adds `issue17_test.go` and `issue18_test.go` (10 cases) covering both bugs, all void elements, the sibling-vs-child distinction, the `show ? "" : "d-none"` conditional-visibility pattern, plus guards for inline output, non-empty vars, and static class lists. Full suite passes; `gofmt` clean; `go vet` passes.
