### PR TITLE
chore(release): stop building demo binaries; release via tag + notes only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,11 @@
 #
 # Jobs:
 #   test    — full test suite + race detector (must pass before releasing)
-#   release — creates a GitHub Release with auto-generated notes and source
-#             archives (.tar.gz / .zip) attached
+#   release — creates a GitHub Release with auto-generated notes
+#
+# Note: go-pug is an importable library — consumers use `go get` against the
+# pushed tag, so no binaries are built or attached here. (./cmd is only a demo
+# server, not a general-purpose CLI.)
 # ---------------------------------------------------------------------------
 
 name: Release
@@ -59,56 +62,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Build demo binary (linux/amd64)
-        run: |
-          GOOS=linux GOARCH=amd64 go build -v \
-            -ldflags "-X github.com/sinfulspartan/go-pug/pkg/gopug.Version=${{ github.ref_name }}" \
-            -o bin/go-pug-linux-amd64 \
-            ./cmd
-
-      - name: Build demo binary (linux/arm64)
-        run: |
-          GOOS=linux GOARCH=arm64 go build -v \
-            -ldflags "-X github.com/sinfulspartan/go-pug/pkg/gopug.Version=${{ github.ref_name }}" \
-            -o bin/go-pug-linux-arm64 \
-            ./cmd
-
-      - name: Build demo binary (windows/amd64)
-        run: |
-          GOOS=windows GOARCH=amd64 go build -v \
-            -ldflags "-X github.com/sinfulspartan/go-pug/pkg/gopug.Version=${{ github.ref_name }}" \
-            -o bin/go-pug-windows-amd64.exe \
-            ./cmd
-
-      - name: Build demo binary (darwin/amd64)
-        run: |
-          GOOS=darwin GOARCH=amd64 go build -v \
-            -ldflags "-X github.com/sinfulspartan/go-pug/pkg/gopug.Version=${{ github.ref_name }}" \
-            -o bin/go-pug-darwin-amd64 \
-            ./cmd
-
-      - name: Build demo binary (darwin/arm64)
-        run: |
-          GOOS=darwin GOARCH=arm64 go build -v \
-            -ldflags "-X github.com/sinfulspartan/go-pug/pkg/gopug.Version=${{ github.ref_name }}" \
-            -o bin/go-pug-darwin-arm64 \
-            ./cmd
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true
-          files: |
-            bin/go-pug-linux-amd64
-            bin/go-pug-linux-arm64
-            bin/go-pug-windows-amd64.exe
-            bin/go-pug-darwin-amd64
-            bin/go-pug-darwin-arm64


### PR DESCRIPTION
go-pug is an importable library — consumers pull it via `go get github.com/sinfulspartan/go-pug@vX.Y.Z` against the pushed tag, which resolves straight from git with no release artifacts required. The five cross-compiled binaries the release workflow produced were only the `./cmd` **demo server** (a showcase of the embedded example gallery), not a general-purpose CLI, and couldn't process user templates — so they added no value to either library consumers or end users.

## Change
- Removes the five per-platform `Build demo binary` steps and their asset uploads from `release.yml`.
- Removes the now-unneeded Go toolchain setup from the `release` job.
- **Unchanged:** the `test` job (full suite + race detector) still gates every release, and the GitHub Release is still created with auto-generated notes.

## Follow-up (not in this PR)
If a real CLI is ever desired (`go-pug render input.pug > out.html`), promoting `./cmd` into a file/stdin tool would make multi-platform binaries worth shipping again.
