### PR TITLE
feat(#21): file-relative top-level includes/extends (standard Pug) — PROTOTYPE

### DIFF
--- a/pkg/gopug/gopug.go
+++ b/pkg/gopug/gopug.go
@@ -53,6 +53,13 @@ type Options struct {
 	Pretty  bool
 	Globals map[string]any
 	Filters map[string]FilterFunc
+
+	// entryFile is the path of the top-level template being rendered, if it
+	// came from a file (RenderFile/CompileFile). It lets top-level relative
+	// includes/extends resolve against the entry file's own directory —
+	// matching standard Pug semantics — instead of falling back to Basedir.
+	// Unexported: set internally, never by callers.
+	entryFile string
 }
 
 func Render(src string, data map[string]any, opts *Options) (string, error) {
@@ -69,14 +76,17 @@ func RenderFile(path string, data map[string]any, opts *Options) (string, error)
 		return "", fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
-	if opts == nil {
-		opts = &Options{}
+	// Copy so we never mutate the caller's Options struct.
+	copied := Options{}
+	if opts != nil {
+		copied = *opts
 	}
-	if opts.Basedir == "" {
-		opts.Basedir = filepath.Dir(path)
+	if copied.Basedir == "" {
+		copied.Basedir = filepath.Dir(path)
 	}
+	copied.entryFile = path
 
-	return Render(string(src), data, opts)
+	return Render(string(src), data, &copied)
 }
 
 func Compile(src string, opts *Options) (*Template, error) {
@@ -118,7 +128,11 @@ func CompileFile(path string, opts *Options) (*Template, error) {
 		// so the cached AST is re-used but per-call options are honoured.
 		if opts != nil {
 			merged := *tpl
-			merged.opts = opts
+			// Preserve the entry-file path for top-level relative resolution;
+			// the caller's Options never carries it.
+			mergedOpts := *opts
+			mergedOpts.entryFile = abs
+			merged.opts = &mergedOpts
 			return &merged, nil
 		}
 		return tpl, nil
@@ -129,15 +143,16 @@ func CompileFile(path string, opts *Options) (*Template, error) {
 		return nil, fmt.Errorf("failed to read file %q: %w", abs, err)
 	}
 
-	if opts == nil {
-		opts = &Options{}
+	// Copy the Options so we don't mutate the caller's struct.
+	copied := Options{}
+	if opts != nil {
+		copied = *opts
 	}
-	if opts.Basedir == "" {
-		// Copy the Options so we don't mutate the caller's struct.
-		copied := *opts
+	if copied.Basedir == "" {
 		copied.Basedir = filepath.Dir(abs)
-		opts = &copied
 	}
+	copied.entryFile = abs
+	opts = &copied
 
 	tpl, err := Compile(string(src), opts)
 	if err != nil {

--- a/pkg/gopug/issue21_test.go
+++ b/pkg/gopug/issue21_test.go
@@ -1,0 +1,162 @@
+package gopug
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #21: include/extends path resolution was inconsistent between the
+// top-level render target (Basedir-relative) and nested includes (file-relative).
+// The fix threads the entry file's path into the runtime so *every* relative
+// include/extends resolves against the directory of the file doing the
+// including — standard Pug semantics — while a leading slash stays
+// Basedir-relative.
+
+// writeTree writes {relpath: contents} under root, creating parent dirs.
+func writeTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, body := range files {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// The core fix: a top-level render target that lives in a SUBDIRECTORY of
+// Basedir now resolves a bare relative include against its own directory, not
+// Basedir. Before the fix this resolved against Basedir and failed.
+func TestIssue21TopLevelInSubdirIsFileRelative(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"layout/page.pug":    "div\n  include _header.pug\n",
+		"layout/_header.pug": "h1 Header\n",
+	})
+
+	out, err := RenderFile(filepath.Join(root, "layout/page.pug"), nil, &Options{Basedir: root})
+	if err != nil {
+		t.Fatalf("RenderFile error: %v", err)
+	}
+	assertEqual(t, out, "<div><h1>Header</h1></div>")
+}
+
+// Nested relative includes were already file-relative — must stay that way.
+func TestIssue21NestedStaysFileRelative(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"top.pug":        "include sub/nested.pug\n",
+		"sub/nested.pug": "div\n  include leaf.pug\n",
+		"sub/leaf.pug":   "span leaf\n",
+	})
+
+	out, err := RenderFile(filepath.Join(root, "top.pug"), nil, &Options{Basedir: root})
+	if err != nil {
+		t.Fatalf("RenderFile error: %v", err)
+	}
+	assertEqual(t, out, "<div><span>leaf</span></div>")
+}
+
+// A leading slash remains Basedir-relative at every depth (the escape hatch).
+func TestIssue21LeadingSlashIsBasedirRelative(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"layout/page.pug":  "div\n  include /shared/_foot.pug\n",
+		"shared/_foot.pug": "footer Foot\n",
+	})
+
+	out, err := RenderFile(filepath.Join(root, "layout/page.pug"), nil, &Options{Basedir: root})
+	if err != nil {
+		t.Fatalf("RenderFile error: %v", err)
+	}
+	assertEqual(t, out, "<div><footer>Foot</footer></div>")
+}
+
+// The payoff from the original issue: a partial used BOTH as a nested include
+// AND rendered directly as a top-level target can now use the *same* bare
+// include line in both roles.
+func TestIssue21DualRolePartialSameIncludeLine(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"page.pug":          "include sub/_fragment.pug\n",
+		"sub/_fragment.pug": "section\n  include _content.pug\n",
+		"sub/_content.pug":  "p Content\n",
+	})
+
+	// Role 1: reached via a nested include from the top-level page.
+	nested, err := RenderFile(filepath.Join(root, "page.pug"), nil, &Options{Basedir: root})
+	if err != nil {
+		t.Fatalf("nested RenderFile error: %v", err)
+	}
+	assertEqual(t, nested, "<section><p>Content</p></section>")
+
+	// Role 2: the same fragment rendered directly as the top-level target —
+	// its bare `include _content.pug` must resolve identically.
+	direct, err := RenderFile(filepath.Join(root, "sub/_fragment.pug"), nil, &Options{Basedir: root})
+	if err != nil {
+		t.Fatalf("direct RenderFile error: %v", err)
+	}
+	assertEqual(t, direct, "<section><p>Content</p></section>")
+}
+
+// extends from a top-level file in a subdirectory resolves file-relative too,
+// in lockstep with includes.
+func TestIssue21ExtendsFileRelativeFromSubdir(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"pages/child.pug": "extends _base.pug\nblock body\n  p Child\n",
+		"pages/_base.pug": "html\n  body\n    block body\n",
+	})
+
+	out, err := RenderFile(filepath.Join(root, "pages/child.pug"), nil, &Options{Basedir: root})
+	if err != nil {
+		t.Fatalf("RenderFile error: %v", err)
+	}
+	assertEqual(t, out, "<html><body><p>Child</p></body></html>")
+}
+
+// A relative include that fails but WOULD resolve against Basedir gets a
+// leading-slash migration hint. A genuine typo does not.
+func TestIssue21BasedirResolveHint(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"layout/page.pug": "include partial/x.pug\n",      // resolves file-relative → layout/partial/x.pug (missing)
+		"partial/x.pug":   "p X\n",                        // ...but exists at Basedir/partial/x.pug
+		"layout/typo.pug": "include does/not/exist.pug\n", // no Basedir candidate either
+	})
+
+	_, err := RenderFile(filepath.Join(root, "layout/page.pug"), nil, &Options{Basedir: root})
+	if err == nil {
+		t.Fatal("expected include-resolution error, got nil")
+	}
+	if !strings.Contains(err.Error(), "leading-slash") {
+		t.Errorf("expected a leading-slash hint, got: %v", err)
+	}
+
+	_, err = RenderFile(filepath.Join(root, "layout/typo.pug"), nil, &Options{Basedir: root})
+	if err == nil {
+		t.Fatal("expected include-resolution error for typo, got nil")
+	}
+	if strings.Contains(err.Error(), "leading-slash") {
+		t.Errorf("hint should not fire for a genuine typo, got: %v", err)
+	}
+}
+
+// String render (no entry file) keeps the documented Basedir-relative fallback
+// for relative includes.
+func TestIssue21StringRenderFallsBackToBasedir(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"widget.pug": "b widget\n",
+	})
+
+	out, err := Render("div\n  include widget.pug\n", nil, &Options{Basedir: root})
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	assertEqual(t, out, "<div><b>widget</b></div>")
+}

--- a/pkg/gopug/runtime.go
+++ b/pkg/gopug/runtime.go
@@ -35,6 +35,7 @@ type Runtime struct {
 	opts             *Options
 	includeBase      string
 	includeStack     []string
+	entryFile        string
 	prettyIndent     int
 }
 
@@ -56,6 +57,9 @@ func NewRuntimeWithOptions(ast *DocumentNode, data map[string]any, opts *Options
 	}
 	if opts != nil && opts.Basedir != "" {
 		r.includeBase = opts.Basedir
+	}
+	if opts != nil && opts.entryFile != "" {
+		r.entryFile = opts.entryFile
 	}
 	return r
 }
@@ -156,7 +160,13 @@ func (r *Runtime) renderExtends() (string, error) {
 	currentPath := ""
 	if len(r.includeStack) > 0 {
 		currentPath = r.includeStack[len(r.includeStack)-1]
+	} else if r.entryFile != "" {
+		// Top-level file render: extends resolves relative to the entry file's
+		// own directory (standard Pug), matching relative includes.
+		currentPath = r.entryFile
 	} else if r.includeBase != "" {
+		// String render (no entry file): fall back to Basedir-relative via a
+		// synthetic root path anchored at Basedir.
 		currentPath = filepath.Join(r.includeBase, "_root_.pug")
 	}
 
@@ -257,7 +267,7 @@ func (r *Runtime) resolveExtendsAST(currentPath string, childAST *DocumentNode) 
 
 	src, err := os.ReadFile(abs)
 	if err != nil {
-		return nil, nil, fmt.Errorf("extends: cannot read %q: %w", abs, err)
+		return nil, nil, fmt.Errorf("extends: cannot read %q: %w%s", abs, err, r.basedirResolveHint(parentPath))
 	}
 	lx := NewLexer(string(src))
 	toks, err := lx.Lex()
@@ -1452,10 +1462,34 @@ func (r *Runtime) renderBlockExpansion(exp *BlockExpansionNode) error {
 
 // renderInclude resolves and renders an include directive.
 //
-// Path resolution: absolute paths are anchored to includeBase; relative paths
-// are resolved against the directory of the innermost active include, falling
-// back to includeBase. .pug files (or no extension) are lexed, parsed, and
-// rendered; all other files are written raw. Cycle detection is via includeStack.
+// basedirResolveHint returns a migration hint for a failed relative
+// include/extends when the *same* path would resolve against Basedir. It only
+// fires when such a file actually exists, so genuine typos don't get a
+// misleading "did you mean /..." suggestion. Returns "" otherwise.
+func (r *Runtime) basedirResolveHint(inclPath string) string {
+	if r.includeBase == "" {
+		return ""
+	}
+	if strings.HasPrefix(inclPath, "/") || strings.HasPrefix(inclPath, "\\") {
+		return "" // already Basedir-relative
+	}
+	cand := filepath.Join(r.includeBase, inclPath)
+	if filepath.Ext(cand) == "" {
+		cand += ".pug"
+	}
+	if _, err := os.Stat(cand); err != nil {
+		return ""
+	}
+	return fmt.Sprintf(" — a file exists at %q; did you mean a leading-slash (Basedir-relative) path %q?",
+		cand, "/"+strings.TrimLeft(inclPath, "/\\"))
+}
+
+// Path resolution (standard Pug semantics): a leading slash is Basedir-relative;
+// every other relative path resolves against the directory of the file doing the
+// including — the innermost active include when nested, or the entry file when
+// at the top level (falling back to Basedir for string renders). .pug files (or
+// no extension) are lexed, parsed, and rendered; all other files are written
+// raw. Cycle detection is via includeStack.
 func (r *Runtime) renderInclude(inc *IncludeNode) error {
 	inclPath := inc.Path
 
@@ -1481,9 +1515,19 @@ func (r *Runtime) renderInclude(inc *IncludeNode) error {
 			resolved = inclPath
 		}
 	} else {
-		base := r.includeBase
-		if len(r.includeStack) > 0 {
+		// Relative include (standard Pug): resolve against the directory of the
+		// file doing the including.
+		//   - nested include → dir of the innermost active include
+		//   - top-level file → dir of the entry file (RenderFile/CompileFile)
+		//   - string render  → fall back to Basedir (no entry file to anchor to)
+		var base string
+		switch {
+		case len(r.includeStack) > 0:
 			base = filepath.Dir(r.includeStack[len(r.includeStack)-1])
+		case r.entryFile != "":
+			base = filepath.Dir(r.entryFile)
+		default:
+			base = r.includeBase
 		}
 		if base == "" {
 			base = "."
@@ -1512,7 +1556,7 @@ func (r *Runtime) renderInclude(inc *IncludeNode) error {
 	if ext == ".pug" {
 		src, err := os.ReadFile(abs)
 		if err != nil {
-			return fmt.Errorf("include: cannot read %q: %w", abs, err)
+			return fmt.Errorf("include: cannot read %q: %w%s", abs, err, r.basedirResolveHint(inclPath))
 		}
 
 		lexer := NewLexer(string(src))
@@ -1539,7 +1583,7 @@ func (r *Runtime) renderInclude(inc *IncludeNode) error {
 
 	raw, err := os.ReadFile(abs)
 	if err != nil {
-		return fmt.Errorf("include: cannot read %q: %w", abs, err)
+		return fmt.Errorf("include: cannot read %q: %w%s", abs, err, r.basedirResolveHint(inclPath))
 	}
 
 	if inc.FilterName != "" {


### PR DESCRIPTION
**Prototype for #21 — not for merge until we settle the version strategy.** Puts the proposed fix in code so the decision is informed by the real diff and blast radius. See the [discussion on #21](https://github.com/sinfulspartan/go-pug/issues/21).

## What it does
Threads the entry file's path (`RenderFile`/`CompileFile`) into the runtime via an unexported `Options.entryFile`, so a **top-level** relative `include`/`extends` resolves against the entry file's own directory — the same rule nested includes already use, and the same rule standard Pug/Jade uses. A **leading slash** stays Basedir-relative at every depth. **String renders** (`Render`, no entry file) keep the documented Basedir-relative fallback.

Root cause was upstream: `RenderFile` discarded the entry path when delegating to `Render(src, …)`, so the runtime never knew the target's directory and fell back to Basedir.

Both the include path (`renderInclude`) and the extends path (`renderExtends`/`resolveExtendsAST` seeding) were changed **in lockstep** off the same `entryFile` source, so top-level `extends layout/x` and top-level `include partial/x` can't drift to different bases.

## Verified before/after resolution matrix

Basedir = `root`. ✅ = renders, ❌ = fails to resolve. The `before` column was captured by running each case against `main`; `after` is this branch's test suite.

| Scenario | Include line | before (`main`) | after (this PR) |
|---|---|---|---|
| Top-level target **at** Basedir root | `include sub/x.pug` | ✅ `root/sub/x.pug` | ✅ `root/sub/x.pug` (unchanged) |
| **Top-level target in a subdir** | `include _header.pug` from `layout/page.pug` | ❌ `root/_header.pug` | ✅ `root/layout/_header.pug` |
| Nested include, bare sibling | `include leaf.pug` in `sub/nested.pug` | ✅ `root/sub/leaf.pug` | ✅ `root/sub/leaf.pug` (unchanged) |
| **Dual-role partial, rendered direct** | `include _content.pug` in `sub/_fragment.pug` as top-level target | ❌ `root/_content.pug` | ✅ `root/sub/_content.pug` |
| Leading slash (escape hatch) | `include /shared/_foot.pug` | ✅ `root/shared/_foot.pug` | ✅ `root/shared/_foot.pug` (unchanged) |
| `extends` from a subdir target | `extends _base.pug` in `pages/child.pug` | ❌ `root/_base.pug` | ✅ `root/pages/_base.pug` |
| String render + Basedir | `include widget.pug` via `Render()` | ✅ `root/widget.pug` | ✅ `root/widget.pug` (unchanged) |

The two ❌→✅ rows are exactly the asymmetry #21 is about; everything else is unchanged. The full existing include/extends suite passes untouched, confirming the common "target at Basedir root" layout is a no-op.

## Migration hint
When a relative include/extends fails but the same path *would* resolve against Basedir, the error now appends:
> `— a file exists at "root/partial/x.pug"; did you mean a leading-slash (Basedir-relative) path "/partial/x.pug"?`

It stats the candidate first, so a genuine typo (no Basedir match) gets no hint.

## Breaking change / version
Projects relying on top-level Basedir-relative resolution from a target **not** at the Basedir root must switch those refs to a leading slash. Targets at the Basedir root are unaffected. This wants a **v0.3.0** bump + CHANGELOG/migration note (not included in this prototype — pending the direction call).

## Open decisions before this leaves prototype
1. Confirm the Pug-compatible direction over everything-Basedir-relative (leaning yes per the thread).
2. Sign off on the string-render fallback staying Basedir-relative.
3. v0.3.0 + migration-note wording.
