### PR TITLE
chore: release v0.3.0 — file-relative includes/extends + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to this project are documented here. This project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## v0.3.0
+
+### Changed (breaking)
+
+- **`include`/`extends` path resolution is now consistent at every nesting depth**
+  and matches standard Pug/Jade semantics. A **relative** path resolves against the
+  directory of the file doing the including; a **leading slash** resolves against
+  `Basedir`.
+
+  Previously, a relative `include`/`extends` in the **top-level render target**
+  resolved against `Basedir`, while the same line in a **nested** included file
+  resolved relative to that file's own directory. Top-level relative paths now
+  resolve relative to the entry file, removing that asymmetry. ([#21])
+
+  A partial can now use the *same* `include` line whether it is pulled in as a
+  nested include or rendered directly as a top-level target.
+
+### Added
+
+- Failed `include`/`extends` resolutions now emit a migration hint when the same
+  path *would* resolve against `Basedir` — e.g.
+  `did you mean a leading-slash (Basedir-relative) path "/partial/x.pug"?`. The
+  hint only appears when such a file actually exists, so genuine typos are not
+  given misleading advice.
+
+### Migration
+
+Only affects projects whose **top-level render target does not sit at the
+`Basedir` root** and which rely on top-level relative paths resolving against
+`Basedir`. If your entry template lives directly in `Basedir`, no change is
+needed.
+
+For an affected top-level template, switch its `Basedir`-relative refs to a
+leading slash:
+
+```pug
+//- before (resolved against Basedir when at the top level)
+extends layout/base.pug
+include partial/nav.pug
+
+//- after (explicitly Basedir-relative)
+extends /layout/base.pug
+include /partial/nav.pug
+```
+
+Genuinely file-relative refs (same-directory siblings, e.g. `include _header.pug`)
+need no change. If a path fails to resolve after upgrading, the error message will
+suggest the leading-slash form when a `Basedir` candidate exists.
+
+Templates rendered from a string via `Compile`/`Render` (no entry file) keep the
+`Basedir`-relative fallback for top-level relative includes.
+
+[#21]: https://github.com/sinfulspartan/go-pug/issues/21
+
+## v0.2.3
+
+- Fix: render output/text siblings after void elements (`br`/`img`/`hr`/…) instead
+  of silently dropping them. ([#17])
+- Fix: `class=` bound to a variable whose value is an empty string no longer leaks
+  the variable's name as a class token. ([#18])
+
+[#17]: https://github.com/sinfulspartan/go-pug/issues/17
+[#18]: https://github.com/sinfulspartan/go-pug/issues/18

--- a/README.md
+++ b/README.md
@@ -585,6 +585,15 @@ include data.txt
 
 Files without a `.pug` extension are included verbatim. An included Pug file shares the current scope and any mixins declared in it become available to the including template.
 
+**Path resolution** (standard Pug semantics, consistent at every nesting depth):
+
+- A **relative** path (`include partials/nav.pug`) resolves against the directory of the **file doing the including** — the entry file for a top-level `include`, or the included file's own directory for a nested one.
+- A **leading slash** (`include /absolute/from/basedir.pug`) resolves against `Basedir`.
+
+The same rule applies to `extends`. This means a partial can use the *same* `include` line whether it is pulled in as a nested include or rendered directly as a top-level target.
+
+> ⚠️ **Changed in v0.3.0** — top-level relative includes/extends previously resolved against `Basedir`; they now resolve relative to the entry file, matching nested includes and standard Pug. See [`CHANGELOG.md`](CHANGELOG.md) for the migration steps.
+
 > ⚠️ **Only include plain partials** — a `.pug` file that begins with `extends` must be rendered at the top level (passed directly to `Render` / `RenderFile`). If you `include` it, the `extends` resolution runs against the top-level document's AST rather than the included file's, producing silently broken output with no error.
 >
 > ```pug
@@ -764,14 +773,14 @@ err := tpl.RenderToWriter(w io.Writer, data map[string]any) error
 
 ```go
 type Options struct {
-    Basedir string                // root directory for absolute paths
+    Basedir string                // root for leading-slash (/foo) include/extends paths
     Pretty  bool                  // pretty-print HTML output
     Globals map[string]any        // data available to all renders
     Filters map[string]FilterFunc // custom filters (receive body text + parsed options)
 }
 ```
 
-`Basedir` defaults to the directory of the template file when using `CompileFile` or `RenderFile`. When using `Compile` or `Render` with relative includes, set `Basedir` explicitly.
+`Basedir` is the root that **leading-slash** include/extends paths (`/layout/base.pug`) resolve against. **Relative** paths resolve against the including file's own directory (see [Includes](#includes)). `Basedir` defaults to the directory of the template file when using `CompileFile` or `RenderFile`. When using `Compile` or `Render` (string source, no entry file), relative top-level includes fall back to `Basedir`, so set it explicitly if you use them.
 
 `Globals` are merged into `data` before rendering; a key present in `data` takes precedence over the same key in `Globals`.
 

--- a/pkg/gopug/version.go
+++ b/pkg/gopug/version.go
@@ -11,4 +11,4 @@ package gopug
 //	-ldflags "-X github.com/sinfulspartan/go-pug/pkg/gopug.Version=vX.Y.Z"
 //
 // so the binary always reports the exact tag that was built from.
-var Version = "v0.2.3"
+var Version = "v0.3.0"


### PR DESCRIPTION
Cuts **v0.3.0** for the breaking include/extends resolution change ([#21], landed in #22).

## Changes
- `version.go` → `v0.3.0`.
- **New `CHANGELOG.md`** with the v0.3.0 breaking-change entry, concrete migration steps (switch top-level `Basedir`-relative refs to a leading slash), and a backfilled v0.2.3 entry.
- **README**: the Includes section now documents the relative-vs-leading-slash rule; the Options section clarifies that `Basedir` is the root for leading-slash paths and that relative paths resolve against the including file.

## Why a minor (not patch)
The include/extends change on `main` is behavior-breaking for projects whose top-level render target isn't at the `Basedir` root and relies on top-level `Basedir`-relative resolution. Semantic versioning → v0.3.0 with a migration note.

No code behavior change in this PR beyond the version string; it's docs + version.

[#21]: https://github.com/sinfulspartan/go-pug/issues/21
