### PR TITLE
fix: attach trailing inline content after multi-line attribute lists (#24)

### DIFF
--- a/pkg/gopug/gopug_test.go
+++ b/pkg/gopug/gopug_test.go
@@ -211,21 +211,44 @@ func TestMultilineAttributesBasic(t *testing.T) {
 }
 
 // TestMultilineAttributesWithInlineText verifies that a tag with multiline
-// attributes followed by inline text content renders correctly.
+// attributes followed by inline text content renders the text as the element's
+// child, not as a following sibling (issue #24).
 func TestMultilineAttributesWithInlineText(t *testing.T) {
 	out := renderTest(t, "button(\n  type=\"button\"\n  id=\"my-btn\"\n) Click Me", nil)
 	assertContains(t, out, `type="button"`)
 	assertContains(t, out, `id="my-btn"`)
-	assertContains(t, out, "Click Me")
+	// The text must be INSIDE the element, not a sibling after </button>.
+	assertContains(t, out, ">Click Me</button>")
 }
 
 // TestMultilineAttributesWithBufferedOutput verifies that a tag with multiline
-// attributes followed by a buffered `= expr` output renders correctly.
+// attributes followed by a buffered `= expr` output renders the output as the
+// element's child, not as a following sibling (issue #24).
 func TestMultilineAttributesWithBufferedOutput(t *testing.T) {
 	out := renderTest(t, "span(\n  data-id=\"1\"\n  style=\"cursor:pointer;\"\n)= \"hello world\"", nil)
 	assertContains(t, out, `data-id="1"`)
 	assertContains(t, out, `style="cursor:pointer;"`)
-	assertContains(t, out, "hello world")
+	// The output must be INSIDE the element, not a sibling after </span>.
+	assertContains(t, out, ">hello world</span>")
+}
+
+// TestMultilineAttributesWithUnescapedOutput verifies that a tag with multiline
+// attributes followed by an unescaped `!= expr` output renders the output as
+// the element's child, not as a following sibling (issue #24).
+func TestMultilineAttributesWithUnescapedOutput(t *testing.T) {
+	out := renderTest(t, "span(\n  data-id=\"1\"\n)!= \"<b>hi</b>\"", nil)
+	assertContains(t, out, `data-id="1"`)
+	// The unescaped output must be INSIDE the element, not a sibling.
+	assertContains(t, out, "><b>hi</b></span>")
+}
+
+// TestMultilineAttributesInlineTextMatchesSingleLine is the core issue #24
+// regression: multiline-attribute and single-line-attribute forms of the same
+// tag with trailing inline text must render identically.
+func TestMultilineAttributesInlineTextMatchesSingleLine(t *testing.T) {
+	multi := renderTest(t, "button(\n  type=\"button\"\n  id=\"b\"\n) Actions", nil)
+	single := renderTest(t, `button(type="button" id="b") Actions`, nil)
+	assertEqual(t, multi, single)
 }
 
 // TestMultilineAttributesNested verifies multiline attributes work correctly

--- a/pkg/gopug/parser.go
+++ b/pkg/gopug/parser.go
@@ -124,6 +124,14 @@ func (p *Parser) parseTag() (Node, error) {
 
 	currentDepth := p.cur.IndentDepth
 
+	// attrEndLine is the source line where the tag's opening ends: the tag
+	// name, its last shorthand class/id, or the closing ) of a (possibly
+	// multi-line) attribute list. Trailing inline content (text, `= expr`,
+	// `!= expr`) belongs to the tag only when it sits on this line. Comparing
+	// against tag.Line instead wrongly rejects content that follows a wrapped
+	// attribute list, emitting it as a sibling (issue #24).
+	attrEndLine := tag.Line
+
 	switch p.cur.Type {
 	case TokenTag:
 		tag.Name = p.cur.Value
@@ -143,18 +151,22 @@ func (p *Parser) parseTag() (Node, error) {
 			} else {
 				tag.Attributes["class"] = &AttributeValue{Value: `"` + className + `"`}
 			}
+			attrEndLine = p.cur.Line
 			p.advance()
 
 		case TokenID:
 			idVal := p.cur.Value
 			tag.Attributes["id"] = &AttributeValue{Value: `"` + idVal + `"`}
+			attrEndLine = p.cur.Line
 			p.advance()
 
 		case TokenAttrStart:
 			p.advance() // consume (
-			if err := p.parseAttributes(tag); err != nil {
+			closeLine, err := p.parseAttributes(tag)
+			if err != nil {
 				return nil, err
 			}
+			attrEndLine = closeLine
 
 		case TokenAttrName:
 			// &attributes emitted outside an AttrStart/AttrEnd block by the lexer.
@@ -195,12 +207,13 @@ func (p *Parser) parseTag() (Node, error) {
 			return nil, fmt.Errorf("expected tag after : at line %d", p.cur.Line)
 
 		case TokenTagEnd:
+			attrEndLine = p.cur.Line
 			p.advance()
 			tag.SelfClose = true
 		}
 	}
 
-	if (p.cur.Type == TokenText || p.cur.Type == TokenInterpolation || p.cur.Type == TokenInterpolationUnescape) && p.cur.IndentDepth == currentDepth && p.cur.Line == tag.Line {
+	if (p.cur.Type == TokenText || p.cur.Type == TokenInterpolation || p.cur.Type == TokenInterpolationUnescape) && p.cur.IndentDepth == currentDepth && p.cur.Line == attrEndLine {
 		line := p.cur.Line
 		col := p.cur.Col
 		nodes := p.collectTextRun(currentDepth)
@@ -217,7 +230,7 @@ func (p *Parser) parseTag() (Node, error) {
 		}
 	}
 
-	if p.cur.Type == TokenCodeBuffered && p.cur.IndentDepth == currentDepth && p.cur.Line == tag.Line {
+	if p.cur.Type == TokenCodeBuffered && p.cur.IndentDepth == currentDepth && p.cur.Line == attrEndLine {
 		code := &CodeNode{Expression: p.cur.Value, Type: CodeBuffered, Line: p.cur.Line, Col: p.cur.Col}
 		p.advance()
 		p.skipNewlines()
@@ -225,7 +238,7 @@ func (p *Parser) parseTag() (Node, error) {
 		return tag, nil
 	}
 
-	if p.cur.Type == TokenCodeUnescaped && p.cur.IndentDepth == currentDepth && p.cur.Line == tag.Line {
+	if p.cur.Type == TokenCodeUnescaped && p.cur.IndentDepth == currentDepth && p.cur.Line == attrEndLine {
 		code := &CodeNode{Expression: p.cur.Value, Type: CodeUnescaped, Line: p.cur.Line, Col: p.cur.Col}
 		p.advance()
 		p.skipNewlines()
@@ -250,8 +263,10 @@ func (p *Parser) parseTag() (Node, error) {
 }
 
 // parseAttributes: for the "class" attribute, values from multiple sources
-// (shorthand + explicit) are merged rather than overwritten.
-func (p *Parser) parseAttributes(tag *TagNode) error {
+// (shorthand + explicit) are merged rather than overwritten. It returns the
+// source line of the closing ) so the caller can attach trailing inline content
+// that sits on that line even when the attribute list wrapped across lines.
+func (p *Parser) parseAttributes(tag *TagNode) (int, error) {
 	for p.cur.Type != TokenAttrEnd && p.cur.Type != TokenEOF {
 		if p.cur.Type == TokenAttrName {
 			name := p.cur.Value
@@ -305,7 +320,7 @@ func (p *Parser) parseAttributes(tag *TagNode) error {
 					}
 					p.advance()
 				} else {
-					return fmt.Errorf("expected attribute value at line %d", p.cur.Line)
+					return 0, fmt.Errorf("expected attribute value at line %d", p.cur.Line)
 				}
 			} else {
 				// Boolean attribute — no = was present; mark explicitly so the
@@ -320,10 +335,11 @@ func (p *Parser) parseAttributes(tag *TagNode) error {
 	}
 
 	if p.cur.Type != TokenAttrEnd {
-		return fmt.Errorf("expected ) at line %d", p.cur.Line)
+		return 0, fmt.Errorf("expected ) at line %d", p.cur.Line)
 	}
+	closeLine := p.cur.Line
 	p.advance()
-	return nil
+	return closeLine, nil
 }
 
 func (p *Parser) parseDoctype() (*DoctypeNode, error) {


### PR DESCRIPTION
Fixes #24.

## Problem
A tag whose attribute list wraps across lines, followed by inline content on the closing `)` line, rendered that content **outside** the element as a following sibling:

```pug
button(
  type="button"
  id="b"
) Actions
```
→ `<button id="b" type="button"></button>Actions` ❌ (single-line attrs render correctly: `…>Actions</button>`)

This affected **all three** inline forms — plain text, buffered `= expr`, and unescaped `!= expr` — since they share the same gate. Introduced by the #17 fix and present through v0.3.0.

## Root cause
The #17 fix decides inline-content-vs-sibling by comparing the following token's line against the tag's **start** line (`tag.Line`, captured at the tag-name token). When the attribute list wraps, the `)` and the trailing content sit on a *later* line, so the check fails and the content falls through to the sibling loop.

## Fix
`parseTag` now tracks `attrEndLine` — the line where the tag's opening actually ends (its last shorthand class/id, or the `)` line now returned by `parseAttributes`) — and gates the three inline branches on it instead of `tag.Line`.

The #17 behavior is preserved: a genuine next-line sibling after a void element still sits on a different line than the `)`/tag name, so it's still correctly rejected. Single-line attributes are unchanged (`attrEndLine == tag.Line`).

## Tests
- Tightened `TestMultilineAttributesWithInlineText` and `TestMultilineAttributesWithBufferedOutput`, which previously only asserted substring presence (passing whether content was inside *or* outside the element) — they now assert the content is a **child** (`>…</tag>`).
- Added `TestMultilineAttributesWithUnescapedOutput` (the `!=` gate) and `TestMultilineAttributesInlineTextMatchesSingleLine` (multi-line ≡ single-line equivalence).

All four fail before the fix and pass after. `go vet`, full suite, `-race`, and CLI build all green.